### PR TITLE
[#63] Rename role to tomcat_role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,76 +2,76 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
-## [Unreleased](https://github.com/idealista/tomcat-role/tree/develop)
+## [Unreleased](https://github.com/idealista/tomcat_role/tree/develop)
 
-## [1.8.0](https://github.com/idealista/tomcat-role/tree/1.8.0)
-[Full Changelog](https://github.com/idealista/tomcat-role/compare/1.7.0...1.8.0)
+## [1.8.0](https://github.com/idealista/tomcat_role/tree/1.8.0)
+[Full Changelog](https://github.com/idealista/tomcat_role/compare/1.7.0...1.8.0)
 ### Added
-- *[#56](https://github.com/idealista/tomcat-role/issues/56) Add Ansible 2.6 support for module maven_artifact* @jnogol
+- *[#56](https://github.com/idealista/tomcat_role/issues/56) Add Ansible 2.6 support for module maven_artifact* @jnogol
 
-## [1.7.0](https://github.com/idealista/tomcat-role/tree/1.7.0)
-[Full Changelog](https://github.com/idealista/tomcat-role/compare/1.6.2...1.7.0)
+## [1.7.0](https://github.com/idealista/tomcat_role/tree/1.7.0)
+[Full Changelog](https://github.com/idealista/tomcat_role/compare/1.6.2...1.7.0)
 ### Changed
-- *[#53](https://github.com/idealista/tomcat-role/issues/53) Allow the option to pass additional environment vars* @sorobon
+- *[#53](https://github.com/idealista/tomcat_role/issues/53) Allow the option to pass additional environment vars* @sorobon
 - *Tomcat version to 8.5.31* @sorobon
 ### Fixed
-- *[#4](https://github.com/idealista/tomcat-role/issues/4) Notify restart handler after new files copied/template* @sorobon
+- *[#4](https://github.com/idealista/tomcat_role/issues/4) Notify restart handler after new files copied/template* @sorobon
 
-## [1.6.2](https://github.com/idealista/tomcat-role/tree/1.6.2)
-[Full Changelog](https://github.com/idealista/tomcat-role/compare/1.6.1...1.6.2)
+## [1.6.2](https://github.com/idealista/tomcat_role/tree/1.6.2)
+[Full Changelog](https://github.com/idealista/tomcat_role/compare/1.6.1...1.6.2)
 ### Changed
-- *[#49](https://github.com/idealista/tomcat-role/issues/49) Updated tomcat version to 8.5.29* @sorobon
+- *[#49](https://github.com/idealista/tomcat_role/issues/49) Updated tomcat version to 8.5.29* @sorobon
 
-## [1.6.1](https://github.com/idealista/tomcat-role/tree/1.6.1)
-[Full Changelog](https://github.com/idealista/tomcat-role/compare/1.6.0...1.6.1)
+## [1.6.1](https://github.com/idealista/tomcat_role/tree/1.6.1)
+[Full Changelog](https://github.com/idealista/tomcat_role/compare/1.6.0...1.6.1)
 ### Changed
-- *[#46](https://github.com/idealista/tomcat-role/issues/46) Updated tomcat version to 8.5.28* @sorobon
+- *[#46](https://github.com/idealista/tomcat_role/issues/46) Updated tomcat version to 8.5.28* @sorobon
 
-## [1.6.0](https://github.com/idealista/tomcat-role/tree/1.6.0)
-[Full Changelog](https://github.com/idealista/tomcat-role/compare/1.5.0...1.6.0)
+## [1.6.0](https://github.com/idealista/tomcat_role/tree/1.6.0)
+[Full Changelog](https://github.com/idealista/tomcat_role/compare/1.5.0...1.6.0)
 ### Added
-- *[#43](https://github.com/idealista/tomcat-role/issues/43) Allow to change log files directory* @sorobon
+- *[#43](https://github.com/idealista/tomcat_role/issues/43) Allow to change log files directory* @sorobon
 
-## [1.5.0](https://github.com/idealista/tomcat-role/tree/1.5.0)
-[Full Changelog](https://github.com/idealista/tomcat-role/compare/1.4.0...1.5.0)
+## [1.5.0](https://github.com/idealista/tomcat_role/tree/1.5.0)
+[Full Changelog](https://github.com/idealista/tomcat_role/compare/1.4.0...1.5.0)
 ### Added
-- *[#40](https://github.com/idealista/tomcat-role/issues/40) Support for addons like java-agents* @sorobon
+- *[#40](https://github.com/idealista/tomcat_role/issues/40) Support for addons like java-agents* @sorobon
 
-## [1.4.0](https://github.com/idealista/tomcat-role/tree/1.4.0)
-[Full Changelog](https://github.com/idealista/tomcat-role/compare/1.3.1...1.4.0)
+## [1.4.0](https://github.com/idealista/tomcat_role/tree/1.4.0)
+[Full Changelog](https://github.com/idealista/tomcat_role/compare/1.3.1...1.4.0)
 ### Added
-- *[#29](https://github.com/idealista/tomcat-role/issues/29) Upgrade molecule* @jdvr
-- *[#26](https://github.com/idealista/tomcat-role/issues/26) Fix to copy extra configuration recursively* @dortegau
-- *[#24](https://github.com/idealista/tomcat-role/issues/24) Follow OWASP recommendations to protect Shutdown port* @dortegau
-- *[#21](https://github.com/idealista/tomcat-role/issues/21) Remove pre-installed folders from webapps* @dortegau
+- *[#29](https://github.com/idealista/tomcat_role/issues/29) Upgrade molecule* @jdvr
+- *[#26](https://github.com/idealista/tomcat_role/issues/26) Fix to copy extra configuration recursively* @dortegau
+- *[#24](https://github.com/idealista/tomcat_role/issues/24) Follow OWASP recommendations to protect Shutdown port* @dortegau
+- *[#21](https://github.com/idealista/tomcat_role/issues/21) Remove pre-installed folders from webapps* @dortegau
 
-## [1.3.1](https://github.com/idealista/tomcat-role/tree/1.3.1)
-[Full Changelog](https://github.com/idealista/tomcat-role/compare/1.3.0...1.3.1)
+## [1.3.1](https://github.com/idealista/tomcat_role/tree/1.3.1)
+[Full Changelog](https://github.com/idealista/tomcat_role/compare/1.3.0...1.3.1)
 ### Fixed
-- *[#17](https://github.com/idealista/tomcat-role/issues/17) Fix war user and group after download* @jdvr
+- *[#17](https://github.com/idealista/tomcat_role/issues/17) Fix war user and group after download* @jdvr
 
-## [1.3.0](https://github.com/idealista/tomcat-role/tree/1.3.0)
-[Full Changelog](https://github.com/idealista/tomcat-role/compare/1.2.0...1.3.0)
+## [1.3.0](https://github.com/idealista/tomcat_role/tree/1.3.0)
+[Full Changelog](https://github.com/idealista/tomcat_role/compare/1.2.0...1.3.0)
 ### Added
-- *[#13](https://github.com/idealista/tomcat-role/issues/13) Add maven repository as a valid download war source* @jdvr
+- *[#13](https://github.com/idealista/tomcat_role/issues/13) Add maven repository as a valid download war source* @jdvr
 
-## [1.2.0](https://github.com/idealista/tomcat-role/tree/1.2.0)
-[Full Changelog](https://github.com/idealista/tomcat-role/compare/1.1.2...1.2.0)
+## [1.2.0](https://github.com/idealista/tomcat_role/tree/1.2.0)
+[Full Changelog](https://github.com/idealista/tomcat_role/compare/1.1.2...1.2.0)
 ### Added
-- *[#5](https://github.com/idealista/tomcat-role/issues/5) Add a name for the downloaded war during deployment* @jdvr
+- *[#5](https://github.com/idealista/tomcat_role/issues/5) Add a name for the downloaded war during deployment* @jdvr
 
-## [1.1.2](https://github.com/idealista/tomcat-role/tree/1.1.2)
-[Full Changelog](https://github.com/idealista/tomcat-role/compare/1.1.0...1.1.2)
+## [1.1.2](https://github.com/idealista/tomcat_role/tree/1.1.2)
+[Full Changelog](https://github.com/idealista/tomcat_role/compare/1.1.0...1.1.2)
 ### Fixed
-- *[#8](https://github.com/idealista/tomcat-role/issues/8) Fix systemd startup* @jmonterrubio
-- *[#6](https://github.com/idealista/tomcat-role/issues/6) Fix conf directory template copy* @jnogol
+- *[#8](https://github.com/idealista/tomcat_role/issues/8) Fix systemd startup* @jmonterrubio
+- *[#6](https://github.com/idealista/tomcat_role/issues/6) Fix conf directory template copy* @jnogol
 
-## [1.1.0](https://github.com/idealista/tomcat-role/tree/1.1.0)
-[Full Changelog](https://github.com/idealista/tomcat-role/compare/1.0.0...1.1.0)
+## [1.1.0](https://github.com/idealista/tomcat_role/tree/1.1.0)
+[Full Changelog](https://github.com/idealista/tomcat_role/compare/1.0.0...1.1.0)
 ### Added
-- *[#1](https://github.com/idealista/tomcat-role/issues/1) Add deploy task* @jdvr
+- *[#1](https://github.com/idealista/tomcat_role/issues/1) Add deploy task* @jdvr
 
 
-## [1.0.0](https://github.com/idealista/tomcat-role/tree/1.0.0)
+## [1.0.0](https://github.com/idealista/tomcat_role/tree/1.0.0)
 ### Added
 - *First release*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/tomcat_role/tree/develop)
+### Changed
+- *[#61](https://github.com/idealista/tomcat_role/issues/61) Update molecule to 3.x* @sorobon
+- *[#63](https://github.com/idealista/tomcat_role/issues/63) Rename role to tomcat_role* @sorobon
 
 ## [1.8.0](https://github.com/idealista/tomcat_role/tree/1.8.0)
 [Full Changelog](https://github.com/idealista/tomcat_role/compare/1.7.0...1.8.0)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![Logo](https://raw.githubusercontent.com/idealista/tomcat-role/master/logo.gif)
+![Logo](https://raw.githubusercontent.com/idealista/tomcat_role/master/logo.gif)
 
-[![Build Status](https://travis-ci.org/idealista/tomcat-role.svg?branch=master)](https://travis-ci.org/idealista/tomcat-role)
+[![Build Status](https://travis-ci.org/idealista/tomcat_role.svg?branch=master)](https://travis-ci.org/idealista/tomcat_role)
 [![Ansible Galaxy](https://img.shields.io/badge/galaxy-idealista.tomcat__role-B62682.svg)](https://galaxy.ansible.com/idealista/tomcat_role)
 
 # Tomcat Ansible role
@@ -35,16 +35,16 @@ This role needs a system with java previously installed. Its really recommended 
 Create or add to your roles dependency file (e.g requirements.yml) from GitHub:
 
 ```
-- src: http://github.com/idealista/tomcat-role.git
+- src: http://github.com/idealista/tomcat_role.git
   scm: git
   version: 1.0.0
   name: tomcat
 ```
 
-or using [Ansible Galaxy](https://galaxy.ansible.com/idealista/tomcat-role/) as origin if you prefer:
+or using [Ansible Galaxy](https://galaxy.ansible.com/idealista/tomcat_role/) as origin if you prefer:
 
 ```
-- src: idealista.tomcat-role
+- src: idealista.tomcat_role
   version: 1.0.0
   name: tomcat
 ```
@@ -94,7 +94,7 @@ See molecule/molecule.yml to check possible testing platforms.
 
 ## Versioning
 
-For the versions available, see the [tags on this repository](https://github.com/idealista/tomcat-role/tags).
+For the versions available, see the [tags on this repository](https://github.com/idealista/tomcat_role/tags).
 
 Additionaly you can see what change in each version in the [CHANGELOG.md](CHANGELOG.md) file.
 
@@ -102,7 +102,7 @@ Additionaly you can see what change in each version in the [CHANGELOG.md](CHANGE
 
 * **Idealista** - *Work with* - [idealista](https://github.com/idealista)
 
-See also the list of [contributors](https://github.com/idealista/Tomcat-role/contributors) who participated in this project.
+See also the list of [contributors](https://github.com/idealista/tomcat_role/contributors) who participated in this project.
 
 ## License
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-# handlers file for tomcat-role
+# handlers file for tomcat_role
 
 - name: restart tomcat
   systemd:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,4 +3,4 @@
 - name: Converge
   hosts: all
   roles:
-    - role: tomcat-role
+    - role: tomcat_role


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Following the Ansible Role name standards, this role should be renamed to "tomcat_role" instead of "tomcat-role".

### Benefits

More compatibility with ansible galaxy.


### Applicable Issues

#63 
