### PR TITLE
Fix the 'no filter named failed' message replacing 'pipe' by 'is'.

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -41,7 +41,7 @@
     owner: "{{ tomcat_user }}"
     group: "{{ tomcat_group }}"
     mode: 0750
-  when: 'tomcat_force_reinstall or tomcat_check|failed or tomcat_check.stdout == "Apache Tomcat/tomcat_version"'
+  when: 'tomcat_force_reinstall or tomcat_check is failed or tomcat_check.stdout == "Apache Tomcat/tomcat_version"'
 
 - name: Tomcat | Copy Daemon script
   template:


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Replacing 'pipe' by 'is' in the when statement


### Benefits

No more errors

### Possible Drawbacks

Do it even if check is not failed

### Applicable Issues

<!-- Enter any applicable Issues here -->
