### PR TITLE
Enabled maxHttpHeaderSize customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/tomcat_role/tree/develop)
+- * Allow the option to change maxHttpHeaderSize value
 
 ## [1.9.0](https://github.com/idealista/tomcat_role/tree/1.9.0)
 [Full Changelog](https://github.com/idealista/tomcat_role/compare/1.8.0...1.9.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ## [Unreleased](https://github.com/idealista/tomcat_role/tree/develop)
 - * Allow the option to change maxHttpHeaderSize value
 
+## [1.9.1](https://github.com/idealista/tomcat_role/tree/1.9.1)
+[Full Changelog](https://github.com/idealista/tomcat_role/compare/1.9.0...1.9.1)
+### Changed
+- *[#81](https://github.com/idealista/tomcat_role/issues/81) Add support to ansible 2.9* @sorobon
+
 ## [1.9.0](https://github.com/idealista/tomcat_role/tree/1.9.0)
 [Full Changelog](https://github.com/idealista/tomcat_role/compare/1.8.0...1.9.0)
 ### Changed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,7 @@ tomcat_extra_conf_template_path: "{{ playbook_dir }}/templates/tomcat/conf"
 
 ## Miscellaneous
 tomcat_force_reinstall: false
+tomcat_max_http_header_size: 8192
 
 ## Ports
 tomcat_shutdown_port: 8005

--- a/templates/server.xml.j2
+++ b/templates/server.xml.j2
@@ -68,7 +68,7 @@
     -->
     <Connector port="{{ tomcat_http_connector_port }}" protocol="HTTP/1.1"
                connectionTimeout="{{ tomcat_http_connector_connection_timeout }}"
-               redirectPort="{{ tomcat_connector_redirect_port }}" />
+               redirectPort="{{ tomcat_connector_redirect_port }}" maxHttpHeaderSize="{{ tomcat_max_http_header_size }}" />
     <!-- A "Connector" using the shared thread pool-->
     <!--
     <Connector executor="tomcatThreadPool"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Add maxHttpHeaderSize option to be able to customize the value as nedeed


### Benefits

To be able to customize maxHttpHeaderSize value

### Possible Drawbacks

No drawbacks if i wrote it well. A default value is included in case you don't set any

### Applicable Issues

