### PR TITLE
Fix check_mode for Tomcat Version Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/tomcat_role/tree/develop)
+### Fixed
+- *Fix check mode for task Check Tomcat version* @agimenez
 
 
 ## [1.10.0](https://github.com/idealista/tomcat_role/tree/1.10.0)

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -30,6 +30,7 @@
   register: tomcat_check
   changed_when: false
   ignore_errors: true
+  check_mode: no
 
 # File permissions based on official documentation: https://tomcat.apache.org/tomcat-8.0-doc/security-howto.html
 - name: Tomcat | Download & Extract Tomcat


### PR DESCRIPTION
### Description of the Change

When running the Ansible in check mode, the task "Download & Extract
Tomcat" fails because the `tomcat_check` variable is not defined.

The cause is that when Ansible runs in check mode, tasks with the
'command' module are not executed. The Tomcat Version check task
executes a java command that registers the `tomcat_check` variable,
which is used in the next task ("Download & Extract Tomcat").

As the command is not executed, the variable does not exist and the
conditional test fails.

Forcing the execution of the command, even in check mode, makes the
variable to be defined and the checks to be successful.

### Benefits

Role does not fail in Ansible check mode

### Possible Drawbacks

Other tasks may have the same problem (I haven't checked).

### Applicable Issues

N/A
