### PR TITLE
Fix tomcat_version variable usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/tomcat_role/tree/develop)
+### Fixed
+- *Fix tomcat_version variable usage in "Download & Extract Tomcat" task* @agimenez
 
 
 ## [1.10.0](https://github.com/idealista/tomcat_role/tree/1.10.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/tomcat_role/tree/develop)
 ### Fixed
-- *Fix tomcat_version variable usage in "Download & Extract Tomcat" task* @agimenez
+- *Fix tomcat_version variable usage and conditional in "Download & Extract Tomcat" task* @agimenez
 - *Fix check mode for task Check Tomcat version* @agimenez
 
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -42,7 +42,7 @@
     owner: "{{ tomcat_user }}"
     group: "{{ tomcat_group }}"
     mode: 0750
-  when: 'tomcat_force_reinstall or tomcat_check is failed or tomcat_check.stdout != "Apache Tomcat/{{ tomcat_version }}"'
+  when: tomcat_force_reinstall or tomcat_check is failed or tomcat_version not in tomcat_check.stdout
 
 - name: Tomcat | Copy Daemon script
   template:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -42,7 +42,7 @@
     owner: "{{ tomcat_user }}"
     group: "{{ tomcat_group }}"
     mode: 0750
-  when: 'tomcat_force_reinstall or tomcat_check is failed or tomcat_check.stdout == "Apache Tomcat/{{ tomcat_version }}"'
+  when: 'tomcat_force_reinstall or tomcat_check is failed or tomcat_check.stdout != "Apache Tomcat/{{ tomcat_version }}"'
 
 - name: Tomcat | Copy Daemon script
   template:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -41,7 +41,7 @@
     owner: "{{ tomcat_user }}"
     group: "{{ tomcat_group }}"
     mode: 0750
-  when: 'tomcat_force_reinstall or tomcat_check is failed or tomcat_check.stdout == "Apache Tomcat/tomcat_version"'
+  when: 'tomcat_force_reinstall or tomcat_check is failed or tomcat_check.stdout == "Apache Tomcat/{{ tomcat_version }}"'
 
 - name: Tomcat | Copy Daemon script
   template:


### PR DESCRIPTION
### Description of the Change

In the "Download & Extract Tomcat" task we try to detect if the tomcat
version to install is the same as the configured in the variables.

The check used the literal `tomcat_version` instead of
interpolating the Jinja2 value like `{{ tomcat_version }}`.

**NOTE: this opens a new changelog "Fixed" section as well as #96**. I will set this as draft as it would cause conflicts on merge. If the other PR is merged in, I will rebase this branch against the latest develop to avoid conflicts.

### Benefits

The check that tries to figure out whether the installed Tomcat is the wanted version in the `tomcat_version` variable should work as expected.

### Possible Drawbacks

TBH, I'm not sure how this was working before. I guess that the particular version check was yelding `false` always.

Also, if I understand correctly, the check should be `!=` instead of `==`, since I believe that this task will download & install if the installed version **is different** from the one we want. Is that right? In such case, I can fix the conditional as well.

### Applicable Issues

N/A
