### PR TITLE
#111 add log4shell prevention flag by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/tomcat_role/tree/develop)
+### Added
+- *[#111](https://github.com/idealista/tomcat_role/issues/111) Set log4j formatMsgNoLookups flag by default* @blalop
 ### Fixed
 - *[#109](https://github.com/idealista/tomcat_role/issues/109) Agents installation logic fix* @blalop
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,6 +43,7 @@ tomcat_connector_redirect_port: 8443
 tomcat_catalina_opts:
   - -Xms512m
   - -Xmx512m
+  - -Dlog4j2.formatMsgNoLookups=true
 
 tomcat_environment_vars:
   - name: UMASK

--- a/molecule/default/tests/test_tomcat.yml
+++ b/molecule/default/tests/test_tomcat.yml
@@ -41,6 +41,12 @@ file:
     exists: true
     contains:
       - '-javaagent:/opt/tomcat/datadog/dd-java-agent-0.73.0.jar -Ddd.profiling.enabled=true -Ddd.logs.injection=true -Ddd.service=sample -Ddd.env=molecule'
+  /opt/tomcat/bin/setenv.sh:
+    exists: true
+    contains:
+      - 'export CATALINA_OPTS="$CATALINA_OPTS -Xms512m"'
+      - 'export CATALINA_OPTS="$CATALINA_OPTS -Xmx512m"'
+      - 'export CATALINA_OPTS="$CATALINA_OPTS -Dlog4j2.formatMsgNoLookups=true"'
   /var/log/tomcat:
     filetype: directory
     exists: true


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Add log4shell prevention flag by default


### Benefits

Provides this flag by default

### Possible Drawbacks

None, as it can be easily overrided.

### Applicable Issues

#111 
